### PR TITLE
Check for recursive types in toEnv function

### DIFF
--- a/gidl.cabal
+++ b/gidl.cabal
@@ -51,7 +51,8 @@ library
                        transformers,
                        ivory-artifact,
                        s-cargot,
-                       text
+                       text,
+                       mtl
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
I realized this shouldn't have been hard, so I just sat down and added the code. It'll detect both recursive types on their own and mutual recursion, and give you an appropriate high-level error message.
